### PR TITLE
Eval datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+dataset_downloads/
+playground.ipynb

--- a/src/scripts/dataset_utils.py
+++ b/src/scripts/dataset_utils.py
@@ -183,6 +183,11 @@ class Dataset():
         return df
     
     ### Getters ###
+    # TODO include a 'level' flag. 
+    # If level = "message", return a dataframe where each row has a message id / conversation id and the requested feature of that message.
+    #   Example: get_feature(level` = "message") => Dataframe(conv_id = [3,3,3], message_id=[4,5,6], feature=[B,C,A])  
+    # If level = "conversation", return a dataframe where each row has the conversation ID, and a *list* of features in that conversation. 
+    #   Example: get_feature(level` = "conversation") => Dataframe(conv_id = [3], feature=[B,C,A]) 
     def get_feature(self, feature, as_pandas = False):
         """
         This function by default returns the data as 2 lists, one of the example ids and one of the requested feature. 

--- a/src/scripts/dataset_utils.py
+++ b/src/scripts/dataset_utils.py
@@ -1,0 +1,206 @@
+import random
+from typing import List
+from torch.utils.data import DataLoader
+import os
+import json
+from datasets import load_dataset
+import pandas as pd
+import json
+import jsonlines
+"""
+This dataset_utils.py file is used to define the Dataset and Conversation objects. A Dataset is used to define the collection of conversations or samples. 
+"""
+
+class Conversation(object):
+    """A conversation object, with all metadata."""
+
+    def __init__(
+        self,
+        ex_id,
+        dataset_id,
+        user_id,
+        time,
+        model,
+        conversation,
+        geography=None,
+        languages=None,
+    ):
+        self.ex_id = ex_id
+        self.dataset_id = dataset_id
+        self.user_id = user_id
+        self.time = time
+        self.model = model
+        self.conversation = conversation
+        self.geography = geography
+        self.languages = languages
+
+    def to_dict(self, unpack_conversation=False):
+        obj = {
+            "ex_id": self.ex_id,
+            "dataset_id": self.dataset_id,
+            "user_id": self.user_id,
+            "time": self.time,
+            "model": self.model,
+            "geography": self.geography,
+            "languages": self.languages,
+        }
+        if unpack_conversation:
+            for i in range(6):
+                obj[f"Turn {i}"] = self.conversation[i]["text"] if i < len(self.conversation) else ""
+        else:
+            obj["conversation"] = self.conversation
+        return obj
+    
+
+DATASET_CATEGORIES = {
+    ### User Datasets ###
+    "wildchat_v1": "usage",
+    "lmsys_1m": "usage",
+    "sharegpt_v1": "usage",
+    ### Benchmarks ###
+    "mmlu": "benchmark",
+}
+
+DATASET_TYPES = {
+    ### User Datasets ###
+    "wildchat_v1": "conversation",
+    "lmsys_1m": "conversation",
+    "sharegpt_v1": "conversation",
+    ### Benchmarks ###
+    "mmlu": "qa",
+}
+
+def process_json_into_conversations(path):
+    conversations = []
+    with open(path, 'r') as file:
+        data = json.load(file)
+        for item in data:
+            conversation = [
+                {"text": turn["text"]} for turn in item["conversation"]
+            ]
+            
+            conv_obj = Conversation(
+                ex_id=item["ex_id"],
+                dataset_id=item["dataset_id"],
+                user_id=item["user_id"],
+                time=item["time"],
+                model=item["model"],
+                conversation=conversation,
+                geography=item["geography"],
+                languages=item["languages"]
+            )
+
+            conversations.append(conv_obj)
+    return conversations
+
+def process_csv_into_conversations(path):
+    conversations = []
+    data = pd.read_csv(path)
+    for _, row in data.iterrows():
+        conv_unpacked = [
+            {"text": row[f"Turn {i}"]} for i in range(6) if pd.notna(row[f"Turn {i}"])
+        ]
+        conv_obj = Conversation(
+            ex_id=row["ex_id"],
+            dataset_id=row["dataset_id"],
+            user_id=row["user_id"],
+            time=row["time"],
+            model=row["model"],
+            conversation=conversation,
+            geography=row["geography"],
+            languages=row["languages"]
+        )
+        conversations.append(conv_obj)
+        
+    return conversations
+
+def process_jsonl_into_conversations(path):
+    conversations = []
+  
+    with jsonlines.open(path) as reader:
+        for item in reader:
+            conversation = [
+                {"text": turn["text"]} for turn in item["conversation"]
+            ]
+            
+            conv_obj = Conversation(
+                ex_id=item["ex_id"],
+                dataset_id=item["dataset_id"],
+                user_id=item["user_id"],
+                time=item["time"],
+                model=item["model"],
+                conversation=conversation,
+                geography=item["geography"],
+                languages=item["languages"]
+            )
+
+            conversations.append(conv_obj)
+    
+    return conversations
+
+def read_data_from_files(dataset_id, local_path=None):
+    """
+    Read data from downloaded file. This is used by the Dataset object to get the data for a specific dataset (specified by the dataset_id). 
+    If no local_path is provided, the function will look for a valid file at '../../dataset_downloads/{dataset_id}/dataset.{json,csv,jsonl}.
+
+    Args:
+        dataset_id (str): The id of the dataset to load.
+        local_path (str, optional): The local path to the dataset. Defaults to None. If not provided, the dataset is loaded via HF API. 
+
+    Returns:
+        List[Conversation]: The loaded dataset as a list of Conversation objects.
+    """
+    conversations = []
+    # print(local_path)
+    # print(os.path.exists(local_path))
+  
+    default_paths_to_check = [f"../../dataset_downloads/{dataset_id}/dataset.json", f"../../dataset_downloads/{dataset_id}/dataset.csv"]
+    
+    # Determine if the provided path is valid, or if the dataset exists at the default save location. 
+    path_to_use = ""
+    if local_path and os.path.exists(local_path):
+        path_to_use = local_path
+    elif os.path.exists(default_paths_to_check[0]): 
+        path_to_use = default_paths_to_check[0]
+    elif os.path.exists(default_paths_to_check[1]): 
+        path_to_use = default_paths_to_check[1]
+    else: 
+        raise ValueError(f"No valid path for {dataset_id} provided, and no valid file found at the default download location of ../../dataset_downloads/{dataset_id}.csv or ../../dataset_downloads/{dataset_id}.json")
+    
+     # If a valid path exists, load it as a list of conversation objects and return. 
+    print(f"Reading File {path_to_use}", flush=True)
+    if path_to_use.endswith('.json'):
+        conversations = process_json_into_conversations(path_to_use)
+    
+    elif path_to_use.endswith('.jsonl'):
+        conversations = process_jsonl_into_conversations(path_to_use)
+    elif path_to_use.endswith('.csv'):
+        conversations = process_csv_into_conversations(path_to_use)
+    else:
+        raise ValueError("Unsupported file format. Only .json and .csv are supported.")
+  
+    return conversations
+
+
+class Dataset(): 
+    """Dataset class used to define the common features / functions of any evaluation or usage dataset."""
+
+    def __init__(self, dataset_id: str, local_path: str = None):
+        assert dataset_id in DATASET_CATEGORIES, f"{dataset_id} not in {DATASET_CATEGORIES.keys()}. Please add it to the DATASET_TYPES Dictionary."
+        self.dataset_id:str = dataset_id
+        self.category:str = DATASET_CATEGORIES[dataset_id]
+        self.data:List[Conversation] = read_data_from_files(dataset_id=dataset_id, local_path = local_path)
+        
+    def __len__(self):
+        return len(self.data)
+
+    def sample(self, n):
+        """Sample n conversations from the dataset."""
+        return random.sample(self.data, n)
+
+    def slice(self, start, end):
+        """Get a slice of the dataset from start to end."""
+        return self.data[start:end]
+
+    def get_dataloader(self, batch_size:int = 32, shuffle:bool = False ):
+        dl = DataLoader(self.data, batch_size=batch_size, shuffle=shuffle)        

--- a/src/scripts/dataset_utils.py
+++ b/src/scripts/dataset_utils.py
@@ -54,20 +54,14 @@ class Conversation(object):
 
 DATASET_CATEGORIES = {
     ### User Datasets ###
-    "wildchat_v1": "usage",
-    "lmsys_1m": "usage",
-    "sharegpt_v1": "usage",
-    ### Benchmarks ###
-    "mmlu": "benchmark",
-}
-
-DATASET_TYPES = {
-    ### User Datasets ###
     "wildchat_v1": "conversation",
     "lmsys_1m": "conversation",
     "sharegpt_v1": "conversation",
+    
     ### Benchmarks ###
-    "mmlu": "qa",
+    "chatbot_arena": "benchmark",
+    "alpaca_eval": "benchmark",
+    "mmlu": "benchmark"
 }
 
 def process_json_into_conversations(path):
@@ -186,7 +180,7 @@ class Dataset():
     """Dataset class used to define the common features / functions of any evaluation or usage dataset."""
 
     def __init__(self, dataset_id: str, local_path: str = None):
-        assert dataset_id in DATASET_CATEGORIES, f"{dataset_id} not in {DATASET_CATEGORIES.keys()}. Please add it to the DATASET_TYPES Dictionary."
+        assert dataset_id in DATASET_CATEGORIES, f"{dataset_id} not in {DATASET_CATEGORIES.keys()}. Please add it to the DATASET_CATEGORIES Dictionary."
         self.dataset_id:str = dataset_id
         self.category:str = DATASET_CATEGORIES[dataset_id]
         self.data:List[Conversation] = read_data_from_files(dataset_id=dataset_id, local_path = local_path)

--- a/src/scripts/dataset_utils.py
+++ b/src/scripts/dataset_utils.py
@@ -4,13 +4,89 @@ from torch.utils.data import DataLoader
 import pandas as pd 
 import os 
 import io
+import jsonlines
+import json
+import warnings
 
 """
-This dataset_utils.py file is used to define the Dataset and Conversation objects. 
+This dataset_utils.py file is used to define the Dataset and Conversation objects, and corresponding functions. 
 A Dataset is used to define the collection of conversations or samples. 
 To download a dataset, use the download_datasets.py file. 
-To load a dataset, use the load_datasets.py file. 
+To load a dataset for use, use the load_datasets.py file. 
 """
+
+###################### Processing Functions ###################### 
+
+def process_csv_into_conversations(path):
+    conversations = []
+    data = pd.read_csv(path)
+    for _, row in data.iterrows():
+        conv_unpacked = [
+            {"text": row[f"Turn {i}"]} for i in range(6) if pd.notna(row[f"Turn {i}"])
+        ]
+        conv_obj = Conversation(
+            ex_id=row["ex_id"],
+            dataset_id=row["dataset_id"],
+            user_id=row["user_id"],
+            time=row["time"],
+            model=row["model"],
+            conversation=conv_unpacked,
+            geography=row["geography"],
+            languages=row["languages"]
+        )
+        conversations.append(conv_obj)
+        
+    return conversations
+
+def process_jsonl_into_conversations(path):
+    conversations = []
+  
+    with jsonlines.open(path) as reader:
+        for item in reader:
+            conversation = [
+                {"text": turn["text"]} for turn in item["conversation"]
+            ]
+            
+            conv_obj = Conversation(
+                ex_id=item["ex_id"],
+                dataset_id=item["dataset_id"],
+                user_id=item["user_id"],
+                time=item["time"],
+                model=item["model"],
+                conversation=conversation,
+                geography=item["geography"],
+                languages=item["languages"]
+            )
+
+            conversations.append(conv_obj)
+    
+    return conversations
+
+def process_json_into_conversations(path):
+    conversations = []
+    with open(path, 'r') as file:
+        data = json.load(file)
+        for item in data:
+            conversation = [
+                {"text": turn["text"]} for turn in item["conversation"]
+            ]
+            
+            conv_obj = Conversation(
+                ex_id=item["ex_id"],
+                dataset_id=item["dataset_id"],
+                user_id=item["user_id"],
+                time=item["time"],
+                model=item["model"],
+                conversation=conversation,
+                geography=item["geography"],
+                languages=item["languages"]
+            )
+
+            conversations.append(conv_obj)
+    return conversations
+
+
+###################### Conversation and Dataset Objects ###################### 
 
 class Conversation(object):
     """A conversation object, with all metadata."""
@@ -52,16 +128,23 @@ class Conversation(object):
             obj["conversation"] = self.conversation
         return obj
     
-
 class Dataset(): 
-    """Dataset class used to define the common features / functions of any evaluation or usage dataset."""
+    """
+    Dataset class used to define the common features / functions of any evaluation or usage dataset. 
+    There are 2 ways to provide data to the Dataset Object: 
+    - If you already have a list of dataset objects, you can pass it in the constructor: e.g. mmlu = Dataset(data = [conv1, conv2]) 
+    - If you don't already have the data loaded, you can read it from file: e.g. mmlu=Dataset(id). mmlu.load_data_from_file(args)
+    """
 
-    def __init__(self, dataset_id: str, data:List[Conversation]):
+    def __init__(self, dataset_id: str, data:List[Conversation] = []):
         self.dataset_id:str = dataset_id
         self.data:List[Conversation] = data
         if len(data) ==0: 
             raise ValueError("No Data Provided to the Dataset class.")
-        self.features = list(data[0].to_dict().keys())
+        if len(self.data) > 0:
+            self.features = list(data[0].to_dict().keys())
+        else: 
+            self.features = []
         
     def __len__(self):
         return len(self.data)
@@ -69,16 +152,29 @@ class Dataset():
     ### Operations ###
     def sample(self, n):
         """Sample n conversations from the dataset."""
-        return random.sample(self.data, n)
+        if len(self.data)>0:
+            return random.sample(self.data, n)
+        else: 
+            warnings.warn("Cannot sample data, as no data has been loaded. Load data by calling load_data_from_file()")
+            return self.data
 
     def slice(self, start, end):
         """Get a slice of the dataset from start to end."""
-        return self.data[start:end]
+        if len(self.data)>0:
+            return self.data[start:end]
+        else: 
+            warnings.warn("Cannot slice data, as no data has been loaded. Load data by calling load_data_from_file()")
+            return self.data
+
 
     def to_pandas(self):
         """
         This function converts the list of conversation objects to a pandas dataframe. It does *NOT* change the underlying self.data state. 
         """
+        if len(self.data)>0:
+            warnings.warn("Cannot convert to pandas, as no data has been loaded. Load data by calling load_data_from_file().")
+            return 
+        
         dicts = []
         for conv in self.data: 
             dicts.append(conv.to_dict())
@@ -92,6 +188,10 @@ class Dataset():
         This function by default returns the data as 2 lists, one of the example ids and one of the requested feature. 
         If as_pandas is set to True, the function returns a pandas Dataframe with two columns, ex_id and the requested feature.
         """
+        if len(self.data)>0:
+            warnings.warn("Cannot get feature, as no data has been loaded. Load data by calling load_data_from_file().")
+            return 
+        
         if feature in self.features: 
             ids = []
             features = []
@@ -113,6 +213,9 @@ class Dataset():
         This function by default returns the data as a list of conversation objects, just without the conversation field. 
         If as_pandas is set to True, the function returns a pandas Dataframe of the metadata.
         """
+        if len(self.data)>0:
+            warnings.warn("Cannot get metadata, as no data has been loaded. Load data by calling load_data_from_file().")
+            return 
         return_conversations = []
         
         for conv in self.data: 
@@ -129,10 +232,56 @@ class Dataset():
             return return_conversations
     
     def get_dataloader(self, batch_size:int = 32, shuffle:bool = False ):
+        if len(self.data)>0:
+            warnings.warn("Cannot get dataloader, as no data has been loaded. Load data by calling load_data_from_file().")
+            return 
         dl = DataLoader(self.data, batch_size=batch_size, shuffle=shuffle)
         return dl 
     
     ### File Operations ###
+    def load_data_from_file(self, path_to_dataset_downloads = ""):
+        """
+        Read data from downloaded file. This is used to load the data for a specific dataset (specified by the dataset_id). 
+        If no path_to_dataset_downloads is provided, the function will look for a valid file at '../../dataset_downloads/{dataset_id}/dataset.{json,csv,jsonl}.
+
+        Args:
+            path_to_dataset_downloads (str, optional): The local path to the dataset. Defaults to None. If not provided, the dataset is loaded via HF API. 
+
+        Returns:
+            List[Conversation]: The loaded dataset as a list of Conversation objects. It is saved 
+        """
+        conversations = []
+  
+        # Check all extensions at the provided folder, as well as the default download location.
+        paths_to_check = [
+            f"{path_to_dataset_downloads}/{self.dataset_id}/dataset.json",
+            f"{path_to_dataset_downloads}/{self.dataset_id}/dataset.jsonl",
+            f"{path_to_dataset_downloads}/{self.dataset_id}/dataset.csv",
+            f"dataset_downloads/{self.dataset_id}/dataset.json",
+            f"dataset_downloads/{self.dataset_id}/dataset.jsonl",
+            f"dataset_downloads/{self.dataset_id}/dataset.csv"
+        ]
+
+        path_to_use = next((path for path in paths_to_check if os.path.exists(path)), None)
+
+        if not path_to_use:
+            raise ValueError(f"No valid file found for {self.dataset_id} in provided directory {path_to_dataset_downloads}/{self.dataset_id}, and no valid file found at the default download location of dataset_downloads/{self.dataset_id}.csv / .jsonl / .json")
+        
+        # If a valid path exists, load it as a list of conversation objects and return. 
+        print(f"Reading File {path_to_use}", flush=True)
+        if path_to_use.endswith('.json'):
+            conversations = process_json_into_conversations(path_to_use)
+        elif path_to_use.endswith('.jsonl'):
+            conversations = process_jsonl_into_conversations(path_to_use)
+        elif path_to_use.endswith('.csv'):
+            conversations = process_csv_into_conversations(path_to_use)
+        else:
+            raise ValueError("Unsupported file format. Only .json, .jsonl, and .csv are supported.")
+    
+        self.data = conversations
+        print(f"Data loaded! Access using .data, .get_dataloader, or .to_pandas")
+        return 
+
     def write_to_file(self, dataset_folder:str, save_path_overwrite: str, dataset_file_type:str = "jsonl"):
         """
         This function writes the loaded data to a file. 
@@ -141,6 +290,10 @@ class Dataset():
             save_path_overwrite: By default, Datasets are saved in {dataset_folder}/{dataset_name}/<actual data files> for consistency. To define a specific save path instead, provide the full path here
              
         """
+        if len(self.data)>0:
+            warnings.warn("Cannot write data to file, as no data has been loaded. Load data by calling load_data_from_file().")
+            return 
+        
         assert dataset_file_type in ["json", "jsonl", "csv"], f"{dataset_file_type} is not one of [json, jsonl, csv]."
         if save_path_overwrite: 
             save_path = save_path_overwrite

--- a/src/scripts/dataset_utils.py
+++ b/src/scripts/dataset_utils.py
@@ -106,7 +106,7 @@ def process_csv_into_conversations(path):
             user_id=row["user_id"],
             time=row["time"],
             model=row["model"],
-            conversation=conversation,
+            conversation=conv_unpacked,
             geography=row["geography"],
             languages=row["languages"]
         )

--- a/src/scripts/dataset_utils.py
+++ b/src/scripts/dataset_utils.py
@@ -8,7 +8,10 @@ import pandas as pd
 import json
 import jsonlines
 """
-This dataset_utils.py file is used to define the Dataset and Conversation objects. A Dataset is used to define the collection of conversations or samples. 
+This dataset_utils.py file is used to define the Dataset and Conversation objects. 
+A Dataset is used to define the collection of conversations or samples. 
+To download a dataset, use the download_datasets.py file. 
+To load a dataset, use the load_datasets.py file. 
 """
 
 class Conversation(object):
@@ -52,138 +55,13 @@ class Conversation(object):
         return obj
     
 
-DATASET_CATEGORIES = {
-    ### User Datasets ###
-    "wildchat_v1": "conversation",
-    "lmsys_1m": "conversation",
-    "sharegpt_v1": "conversation",
-    
-    ### Benchmarks ###
-    "chatbot_arena": "benchmark",
-    "alpaca_eval": "benchmark",
-    "mmlu": "benchmark"
-}
-
-def process_json_into_conversations(path):
-    conversations = []
-    with open(path, 'r') as file:
-        data = json.load(file)
-        for item in data:
-            conversation = [
-                {"text": turn["text"]} for turn in item["conversation"]
-            ]
-            
-            conv_obj = Conversation(
-                ex_id=item["ex_id"],
-                dataset_id=item["dataset_id"],
-                user_id=item["user_id"],
-                time=item["time"],
-                model=item["model"],
-                conversation=conversation,
-                geography=item["geography"],
-                languages=item["languages"]
-            )
-
-            conversations.append(conv_obj)
-    return conversations
-
-def process_csv_into_conversations(path):
-    conversations = []
-    data = pd.read_csv(path)
-    for _, row in data.iterrows():
-        conv_unpacked = [
-            {"text": row[f"Turn {i}"]} for i in range(6) if pd.notna(row[f"Turn {i}"])
-        ]
-        conv_obj = Conversation(
-            ex_id=row["ex_id"],
-            dataset_id=row["dataset_id"],
-            user_id=row["user_id"],
-            time=row["time"],
-            model=row["model"],
-            conversation=conv_unpacked,
-            geography=row["geography"],
-            languages=row["languages"]
-        )
-        conversations.append(conv_obj)
-        
-    return conversations
-
-def process_jsonl_into_conversations(path):
-    conversations = []
-  
-    with jsonlines.open(path) as reader:
-        for item in reader:
-            conversation = [
-                {"text": turn["text"]} for turn in item["conversation"]
-            ]
-            
-            conv_obj = Conversation(
-                ex_id=item["ex_id"],
-                dataset_id=item["dataset_id"],
-                user_id=item["user_id"],
-                time=item["time"],
-                model=item["model"],
-                conversation=conversation,
-                geography=item["geography"],
-                languages=item["languages"]
-            )
-
-            conversations.append(conv_obj)
-    
-    return conversations
-
-def read_data_from_files(dataset_id, local_path=None):
-    """
-    Read data from downloaded file. This is used by the Dataset object to get the data for a specific dataset (specified by the dataset_id). 
-    If no local_path is provided, the function will look for a valid file at '../../dataset_downloads/{dataset_id}/dataset.{json,csv,jsonl}.
-
-    Args:
-        dataset_id (str): The id of the dataset to load.
-        local_path (str, optional): The local path to the dataset. Defaults to None. If not provided, the dataset is loaded via HF API. 
-
-    Returns:
-        List[Conversation]: The loaded dataset as a list of Conversation objects.
-    """
-    conversations = []
-    # print(local_path)
-    # print(os.path.exists(local_path))
-  
-    default_paths_to_check = [f"../../dataset_downloads/{dataset_id}/dataset.json", f"../../dataset_downloads/{dataset_id}/dataset.csv"]
-    
-    # Determine if the provided path is valid, or if the dataset exists at the default save location. 
-    path_to_use = ""
-    if local_path and os.path.exists(local_path):
-        path_to_use = local_path
-    elif os.path.exists(default_paths_to_check[0]): 
-        path_to_use = default_paths_to_check[0]
-    elif os.path.exists(default_paths_to_check[1]): 
-        path_to_use = default_paths_to_check[1]
-    else: 
-        raise ValueError(f"No valid path for {dataset_id} provided, and no valid file found at the default download location of ../../dataset_downloads/{dataset_id}.csv or ../../dataset_downloads/{dataset_id}.json")
-    
-     # If a valid path exists, load it as a list of conversation objects and return. 
-    print(f"Reading File {path_to_use}", flush=True)
-    if path_to_use.endswith('.json'):
-        conversations = process_json_into_conversations(path_to_use)
-    
-    elif path_to_use.endswith('.jsonl'):
-        conversations = process_jsonl_into_conversations(path_to_use)
-    elif path_to_use.endswith('.csv'):
-        conversations = process_csv_into_conversations(path_to_use)
-    else:
-        raise ValueError("Unsupported file format. Only .json and .csv are supported.")
-  
-    return conversations
-
-
 class Dataset(): 
     """Dataset class used to define the common features / functions of any evaluation or usage dataset."""
 
-    def __init__(self, dataset_id: str, local_path: str = None):
-        assert dataset_id in DATASET_CATEGORIES, f"{dataset_id} not in {DATASET_CATEGORIES.keys()}. Please add it to the DATASET_CATEGORIES Dictionary."
+    def __init__(self, dataset_id: str, data:List[Conversation]):
         self.dataset_id:str = dataset_id
         self.category:str = DATASET_CATEGORIES[dataset_id]
-        self.data:List[Conversation] = read_data_from_files(dataset_id=dataset_id, local_path = local_path)
+        self.data:List[Conversation] = data
         
     def __len__(self):
         return len(self.data)
@@ -197,4 +75,5 @@ class Dataset():
         return self.data[start:end]
 
     def get_dataloader(self, batch_size:int = 32, shuffle:bool = False ):
-        dl = DataLoader(self.data, batch_size=batch_size, shuffle=shuffle)        
+        dl = DataLoader(self.data, batch_size=batch_size, shuffle=shuffle)
+        return dl         

--- a/src/scripts/dataset_utils.py
+++ b/src/scripts/dataset_utils.py
@@ -1,12 +1,8 @@
 import random
 from typing import List
 from torch.utils.data import DataLoader
-import os
-import json
-from datasets import load_dataset
-import pandas as pd
-import json
-import jsonlines
+import pandas as pd 
+
 """
 This dataset_utils.py file is used to define the Dataset and Conversation objects. 
 A Dataset is used to define the collection of conversations or samples. 
@@ -60,8 +56,10 @@ class Dataset():
 
     def __init__(self, dataset_id: str, data:List[Conversation]):
         self.dataset_id:str = dataset_id
-        self.category:str = DATASET_CATEGORIES[dataset_id]
         self.data:List[Conversation] = data
+        if len(data) ==0: 
+            raise ValueError("No Data Provided to the Dataset class.")
+        self.features = list(data[0].to_dict().keys())
         
     def __len__(self):
         return len(self.data)
@@ -76,4 +74,62 @@ class Dataset():
 
     def get_dataloader(self, batch_size:int = 32, shuffle:bool = False ):
         dl = DataLoader(self.data, batch_size=batch_size, shuffle=shuffle)
-        return dl         
+        return dl 
+    
+    def to_pandas(self):
+        """
+        This function converts the list of conversation objects to a pandas dataframe. It does *NOT* change the underlying self.data state. 
+        """
+        dicts = []
+        for conv in self.data: 
+            dicts.append(conv.to_dict())
+
+        df = pd.DataFrame.from_dict(dicts)
+        return df
+    
+    def get_feature(self, feature, as_pandas = False):
+        """
+        This function by default returns the data as 2 lists, one of the example ids and one of the requested feature. 
+        If as_pandas is set to True, the function returns a pandas Dataframe with two columns, ex_id and the requested feature.
+        """
+        if feature in self.features: 
+            ids = []
+            features = []
+            for conv in self.data: 
+                conv_dict = conv.to_dict()
+                ids.append(conv_dict["ex_id"])
+                features.append(conv_dict[feature])
+            
+            if as_pandas: 
+                return pd.DataFrame.from_dict({"ex_id": ids, f"{feature}": features})
+            else: 
+                return ids, features
+        else: 
+            print(f"Requested Feature not Found in this Dataset. Available Features Include: {self.features}")
+        return 
+
+    def get_metadata_only(self, as_pandas = False): 
+        """
+        This function by default returns the data as a list of conversation objects, just without the conversation field. 
+        If as_pandas is set to True, the function returns a pandas Dataframe of the metadata.
+        """
+        return_conversations = []
+        
+        for conv in self.data: 
+            conv_dict = conv.to_dict()
+            conv_dict.pop("conversation", None)
+            if as_pandas: 
+                return_conversations.append(conv_dict)
+            else:
+                return_conversations.append(Conversation(**conv_dict))
+        
+        if as_pandas: 
+            return pd.DataFrame.from_dict(return_conversations)
+        else: 
+            return return_conversations
+            
+
+
+        
+    
+        

--- a/src/scripts/download_datasets.py
+++ b/src/scripts/download_datasets.py
@@ -226,14 +226,16 @@ def download_mmlu():
     # ['question', 'choices', 'answer'],
     categories = ['abstract_algebra', 'anatomy', 'astronomy', 'business_ethics', 'clinical_knowledge', 'college_biology', 'college_chemistry', 'college_computer_science', 'college_mathematics', 'college_medicine', 'college_physics', 'computer_security', 'conceptual_physics', 'econometrics', 'electrical_engineering', 'elementary_mathematics', 'formal_logic', 'global_facts', 'high_school_biology', 'high_school_chemistry', 'high_school_computer_science', 'high_school_european_history', 'high_school_geography', 'high_school_government_and_politics', 'high_school_macroeconomics', 'high_school_mathematics', 'high_school_microeconomics', 'high_school_physics', 'high_school_psychology', 'high_school_statistics', 'high_school_us_history', 'high_school_world_history', 'human_aging', 'human_sexuality', 'international_law', 'jurisprudence', 'logical_fallacies', 'machine_learning', 'management', 'marketing', 'medical_genetics', 'miscellaneous', 'moral_disputes', 'moral_scenarios', 'nutrition', 'philosophy', 'prehistory', 'professional_accounting', 'professional_law', 'professional_medicine', 'professional_psychology', 'public_relations', 'security_studies', 'sociology', 'us_foreign_policy', 'virology', 'world_religions']
 
+    choice_indiciators = ["a)", "b)", "c)", "d)", "e)", "f)", "g)", "h)", "i)", "j)", "k)", "l)", "m)", "n)", "o)", "p)", "q)", "r)", "s)", "t)", "u)", "v)", "w)", "x)", "y)", "z)"]
 
     def process_data(datum):
             conv = [{
                     "role": "user",
                     "turn": 1, 
-                    "text": datum.get("question")
+                    "text": datum.get("question") + " " + " ".join(f"{choice_indiciators[i]} {datum.get("choices")[i]}" for i in range(len(datum.get("choices"))))
                     }
                     ]
+            print(conv)
 
             return Conversation(
                 ex_id="mmlu_" + str(uuid.uuid4()),

--- a/src/scripts/download_datasets.py
+++ b/src/scripts/download_datasets.py
@@ -217,6 +217,37 @@ def download_alpaca_eval():
 
     return [process_data(datum) for datum in dset] 
 
+def download_mmlu():
+    # ['question', 'choices', 'answer'],
+    categories = ['abstract_algebra', 'anatomy', 'astronomy', 'business_ethics', 'clinical_knowledge', 'college_biology', 'college_chemistry', 'college_computer_science', 'college_mathematics', 'college_medicine', 'college_physics', 'computer_security', 'conceptual_physics', 'econometrics', 'electrical_engineering', 'elementary_mathematics', 'formal_logic', 'global_facts', 'high_school_biology', 'high_school_chemistry', 'high_school_computer_science', 'high_school_european_history', 'high_school_geography', 'high_school_government_and_politics', 'high_school_macroeconomics', 'high_school_mathematics', 'high_school_microeconomics', 'high_school_physics', 'high_school_psychology', 'high_school_statistics', 'high_school_us_history', 'high_school_world_history', 'human_aging', 'human_sexuality', 'international_law', 'jurisprudence', 'logical_fallacies', 'machine_learning', 'management', 'marketing', 'medical_genetics', 'miscellaneous', 'moral_disputes', 'moral_scenarios', 'nutrition', 'philosophy', 'prehistory', 'professional_accounting', 'professional_law', 'professional_medicine', 'professional_psychology', 'public_relations', 'security_studies', 'sociology', 'us_foreign_policy', 'virology', 'world_religions']
+
+
+    def process_data(datum):
+            conv = [{
+                    "role": "user",
+                    "turn": 0, 
+                    "text": datum.get("question")
+                    }
+                    ]
+
+            return Conversation(
+                ex_id="mmlu_" + str(uuid.uuid4()),
+                dataset_id="mmlu",
+                user_id=str(uuid.uuid4()),
+                time=None,
+                model=None,
+                conversation=conv,
+                geography="Unknown",
+                languages="English"
+            )
+    
+    conversations_to_return = []
+    for category in categories:
+        dset = load_dataset("tasksource/mmlu", category, token=True)
+        for datum in dset:
+            conversations_to_return.append(process_data(datum))
+    
+    return conversations_to_return
 
 
 DOWNLOAD_FUNCTIONS = {
@@ -224,7 +255,8 @@ DOWNLOAD_FUNCTIONS = {
     "lmsys_1m": download_lmsys_1m,
     "sharegpt_v1": download_sharegpt_v1,
     "chatbot_arena": download_chatbot_arena,
-    "alpaca_eval": download_alpaca_eval
+    "alpaca_eval": download_alpaca_eval,
+    "mmlu": download_mmlu
 }
 
 

--- a/src/scripts/download_datasets.py
+++ b/src/scripts/download_datasets.py
@@ -187,7 +187,7 @@ def download_chatbot_arena():
     
     return conversations_to_return
 
-
+# Download Alpaca Eval
 def download_alpaca_eval():
     dset = load_dataset("tatsu-lab/alpaca_eval", split = "eval", trust_remote_code=True, token = True) #TODO integrate this with io helpers
 
@@ -217,6 +217,7 @@ def download_alpaca_eval():
 
     return [process_data(datum) for datum in dset] 
 
+# Download MMLU
 def download_mmlu():
     # ['question', 'choices', 'answer'],
     categories = ['abstract_algebra', 'anatomy', 'astronomy', 'business_ethics', 'clinical_knowledge', 'college_biology', 'college_chemistry', 'college_computer_science', 'college_mathematics', 'college_medicine', 'college_physics', 'computer_security', 'conceptual_physics', 'econometrics', 'electrical_engineering', 'elementary_mathematics', 'formal_logic', 'global_facts', 'high_school_biology', 'high_school_chemistry', 'high_school_computer_science', 'high_school_european_history', 'high_school_geography', 'high_school_government_and_politics', 'high_school_macroeconomics', 'high_school_mathematics', 'high_school_microeconomics', 'high_school_physics', 'high_school_psychology', 'high_school_statistics', 'high_school_us_history', 'high_school_world_history', 'human_aging', 'human_sexuality', 'international_law', 'jurisprudence', 'logical_fallacies', 'machine_learning', 'management', 'marketing', 'medical_genetics', 'miscellaneous', 'moral_disputes', 'moral_scenarios', 'nutrition', 'philosophy', 'prehistory', 'professional_accounting', 'professional_law', 'professional_medicine', 'professional_psychology', 'public_relations', 'security_studies', 'sociology', 'us_foreign_policy', 'virology', 'world_religions']

--- a/src/scripts/download_datasets.py
+++ b/src/scripts/download_datasets.py
@@ -32,7 +32,7 @@ def download_lmsys_1m():
         conversation = [
             {
                 "role": msg.get("role"),
-                "turn": idx,
+                "turn": idx +1, # start at 1 for consistency
                 "text": msg.get("content", "")
             }
             for idx, msg in enumerate(datum.get("conversation", []))
@@ -65,7 +65,7 @@ def download_wildchat_v1():
         conversation = [
             {
                 "role": msg.get("role"),
-                "turn": idx,
+                "turn": idx +1, # start turn count at 1
                 "text": msg.get("content", "")
             }
             for idx, msg in enumerate(datum.get("conversation", []))
@@ -113,7 +113,7 @@ def download_sharegpt_v1():
             assert msg.get("from", "") in sharegpt_systems, "Error: " + msg["from"]
             conversation.append({
                 "role": msg.get("from"),
-                "turn": idx,
+                "turn": idx + 1, # start turn count at 1
                 "text": msg.get("value", "")
             })
 
@@ -136,7 +136,7 @@ def download_chatbot_arena():
     dset = io.huggingface_download("lmsys/chatbot_arena_conversations", split="train")
 
     def add_turn_and_rename_keys(conv:list[object]):
-        turn_count = 0
+        turn_count = 1
         conv_with_turn = []
         for statement in conv:
             statement["turn"] = turn_count
@@ -199,11 +199,11 @@ def download_alpaca_eval():
     def process_data(datum):
         conv = [{
                 "role": "user",
-                "turn": 0, 
+                "turn": 1, 
                 "text": datum.get("instruction")
                 }, {
                 "role": "assistant",
-                "turn": 0, 
+                "turn": 1, 
                 "text": datum.get("output")
                 }]
 
@@ -232,7 +232,7 @@ def download_mmlu():
     def process_data(datum):
             conv = [{
                     "role": "user",
-                    "turn": 0, 
+                    "turn": 1, 
                     "text": datum.get("question")
                     }
                     ]

--- a/src/scripts/download_datasets.py
+++ b/src/scripts/download_datasets.py
@@ -141,8 +141,7 @@ def download_chatbot_arena():
         for statement in conv:
             statement["turn"] = turn_count
             statement["text"] = statement.pop("content")
-            if statement["role"] == "assistant":
-                turn_count = turn_count+1
+            turn_count = turn_count+1
             conv_with_turn.append(statement)
         return conv_with_turn
 

--- a/src/scripts/download_datasets.py
+++ b/src/scripts/download_datasets.py
@@ -6,6 +6,7 @@ import pandas as pd
 import random
 from datetime import datetime
 from huggingface_hub import hf_hub_download
+from datasets import load_dataset
 
 sys.path.append("./")
 sys.path.append("src/")
@@ -13,6 +14,7 @@ from dataset_utils import Conversation
 
 from helpers import constants
 from helpers import io
+import uuid
 
 """
 This file is used to download and format datasets in a common format (list of Conversation objects). To use the datasets, use the 
@@ -186,12 +188,43 @@ def download_chatbot_arena():
     return conversations_to_return
 
 
+def download_alpaca_eval():
+    dset = load_dataset("tatsu-lab/alpaca_eval", split = "eval", trust_remote_code=True, token = True) #TODO integrate this with io helpers
+
+    def process_data(datum):
+        conv = [{
+                "role": "user",
+                "turn": 0, 
+                "text": datum.get("instruction")
+                }, {
+                "role": "assistant",
+                "turn": 0, 
+                "text": datum.get("output")
+                }]
+
+        
+        return Conversation(
+            ex_id="alpaca_eval_" + str(uuid.uuid4()),
+            dataset_id="alpaca_eval",
+            user_id=str(uuid.uuid4()),
+            time=None,
+            model=datum.get('generator'),
+            conversation=conv,
+            geography="Unknown",
+            languages="English"
+        )
+        
+
+    return [process_data(datum) for datum in dset] 
+
+
 
 DOWNLOAD_FUNCTIONS = {
     "wildchat_v1": download_wildchat_v1,
     "lmsys_1m": download_lmsys_1m,
     "sharegpt_v1": download_sharegpt_v1,
-    "chatbot_arena": download_chatbot_arena
+    "chatbot_arena": download_chatbot_arena,
+    "alpaca_eval": download_alpaca_eval
 }
 
 

--- a/src/scripts/load_datasets.py
+++ b/src/scripts/load_datasets.py
@@ -1,0 +1,216 @@
+import pandas as pd 
+import jsonlines 
+import json
+import argparse
+import os
+from typing import Literal
+import numpy as np
+import sys
+sys.path.append("./")
+sys.path.append("src/")
+from src.scripts.dataset_utils import Dataset, Conversation
+
+def process_csv_into_conversations(path):
+    conversations = []
+    data = pd.read_csv(path)
+    for _, row in data.iterrows():
+        conv_unpacked = [
+            {"text": row[f"Turn {i}"]} for i in range(6) if pd.notna(row[f"Turn {i}"])
+        ]
+        conv_obj = Conversation(
+            ex_id=row["ex_id"],
+            dataset_id=row["dataset_id"],
+            user_id=row["user_id"],
+            time=row["time"],
+            model=row["model"],
+            conversation=conv_unpacked,
+            geography=row["geography"],
+            languages=row["languages"]
+        )
+        conversations.append(conv_obj)
+        
+    return conversations
+
+def process_jsonl_into_conversations(path):
+    conversations = []
+  
+    with jsonlines.open(path) as reader:
+        for item in reader:
+            conversation = [
+                {"text": turn["text"]} for turn in item["conversation"]
+            ]
+            
+            conv_obj = Conversation(
+                ex_id=item["ex_id"],
+                dataset_id=item["dataset_id"],
+                user_id=item["user_id"],
+                time=item["time"],
+                model=item["model"],
+                conversation=conversation,
+                geography=item["geography"],
+                languages=item["languages"]
+            )
+
+            conversations.append(conv_obj)
+    
+    return conversations
+
+def process_json_into_conversations(path):
+    conversations = []
+    with open(path, 'r') as file:
+        data = json.load(file)
+        for item in data:
+            conversation = [
+                {"text": turn["text"]} for turn in item["conversation"]
+            ]
+            
+            conv_obj = Conversation(
+                ex_id=item["ex_id"],
+                dataset_id=item["dataset_id"],
+                user_id=item["user_id"],
+                time=item["time"],
+                model=item["model"],
+                conversation=conversation,
+                geography=item["geography"],
+                languages=item["languages"]
+            )
+
+            conversations.append(conv_obj)
+    return conversations
+
+def read_data_from_files(dataset_id, path_to_dataset_downloads=""):
+    """
+    Read data from downloaded file. This is used by the Dataset object to get the data for a specific dataset (specified by the dataset_id). 
+    If no path_to_dataset_downloads is provided, the function will look for a valid file at '../../dataset_downloads/{dataset_id}/dataset.{json,csv,jsonl}.
+
+    Args:
+        dataset_id (str): The id of the dataset to load.
+        path_to_dataset_downloads (str, optional): The local path to the dataset. Defaults to None. If not provided, the dataset is loaded via HF API. 
+
+    Returns:
+        List[Conversation]: The loaded dataset as a list of Conversation objects.
+    """
+    conversations = []
+  
+    # Check all extensions at the provided folder, as well as the default download location.
+    paths_to_check = [
+        f"{path_to_dataset_downloads}/{dataset_id}/dataset.json",
+        f"{path_to_dataset_downloads}/{dataset_id}/dataset.jsonl",
+        f"{path_to_dataset_downloads}/{dataset_id}/dataset.csv",
+        f"dataset_downloads/{dataset_id}/dataset.json",
+        f"dataset_downloads/{dataset_id}/dataset.jsonl",
+        f"dataset_downloads/{dataset_id}/dataset.csv"
+    ]
+
+    path_to_use = next((path for path in paths_to_check if os.path.exists(path)), None)
+
+    if not path_to_use:
+        raise ValueError(f"No valid file found for {dataset_id} in provided directory {path_to_dataset_downloads}/{dataset_id}, and no valid file found at the default download location of dataset_downloads/{dataset_id}.csv / .jsonl / .json")
+    
+     # If a valid path exists, load it as a list of conversation objects and return. 
+    print(f"Reading File {path_to_use}", flush=True)
+    if path_to_use.endswith('.json'):
+        conversations = process_json_into_conversations(path_to_use)
+    elif path_to_use.endswith('.jsonl'):
+        conversations = process_jsonl_into_conversations(path_to_use)
+    elif path_to_use.endswith('.csv'):
+        conversations = process_csv_into_conversations(path_to_use)
+    else:
+        raise ValueError("Unsupported file format. Only .json, .jsonl, and .csv are supported.")
+  
+    return conversations
+
+
+DATASET_LOCATIONS = {
+    ### User Datasets ###
+    "wildchat_v1": "dataset_downloads/wildchat_v1",
+    "lmsys_1m": "dataset_downloads/lmsys_1m",
+    "sharegpt_v1": "dataset_downloads/sharegpt_v1",
+
+    ### Benchmarks ###
+    "chatbot_arena": "dataset_downloads/chatbot_arena",
+    "alpaca_eval": "dataset_downloads/alpaca_eval",
+    "mmlu": "dataset_downloads/mmlu"
+}
+DATASET_CATEGORIES = {
+    ### User Datasets ###
+    "wildchat_v1": "conversation",
+    "lmsys_1m": "conversation",
+    "sharegpt_v1": "conversation",
+    
+    ### Benchmarks ###
+    "chatbot_arena": "benchmark",
+    "alpaca_eval": "benchmark",
+    "mmlu": "benchmark"
+}
+DATASET_SIZES = {
+    ### User Datasets ###
+    "wildchat_v1": 1000000,
+    "lmsys_1m": 1000000,
+    "sharegpt_v1": 90665,
+    
+    ### Benchmarks ###
+    "chatbot_arena": 66000,
+    "alpaca_eval":  805,
+    "mmlu": 14042
+}
+
+def filter_by_id(ids: list[str]):
+    valid_ids = []
+    for id in ids: 
+        if id in DATASET_LOCATIONS.keys():
+            valid_ids.append(id)
+        else: 
+            print(f"\n\n**** WARNING: {id} was not found as a valid dataset id. Available datasets include: {DATASET_LOCATIONS.keys()}")
+    return valid_ids
+
+def filter_by_categories(categories: list[str]):
+    valid_ids = []
+    for id, category in DATASET_CATEGORIES.items():
+        if category in categories:
+            valid_ids.append(id)
+    if len(valid_ids) == 0: 
+        print(f"\n\n**** WARNING: no datasets were found with the provided categories. Available categories include: {list(set(DATASET_LOCATIONS.values()))}")
+    return valid_ids
+
+def filter_by_size(size_range:list[int]):
+    valid_ids = []
+    for id, size in DATASET_SIZES.items(): 
+        if size >= size_range[1] and size <= size_range[0]: 
+            valid_ids.append(id)
+    if len(valid_ids) == 0: 
+        print(f"\n\n**** WARNING: no datasets were found within the provided size range of {size_range}. The sizes of available datasets are: {', '.join([f'\n{key}: {value}' for key, value in DATASET_SIZES.items()])}")
+    
+    return []
+
+def load_datasets(by: Literal["id", "category", "size"], ids=[], categories=[], size_range =[], path_to_dataset_downloads =""):
+    # Find the dataset ids that match the specifications
+    if by == "id": 
+        if len(ids) == 0: 
+            raise ValueError(f"You've specified loading datasets by ID, but have not provided any dataset ids. Try something like: load_datasets(by='id', ids=['mmlu'])")
+        matching_dataset_ids = filter_by_id(ids)
+
+    elif by == "category": 
+        if len(categories) == 0: 
+            raise ValueError(f"You've specified loading datasets by categories, but have not provided any categories. Try something like: load_datasets(by='category', categories=['benchmark'])")
+        matching_dataset_ids = filter_by_categories(categories)
+
+    elif by == "size":
+        if len(size_range) < 2: 
+            raise ValueError(f"You've specified loading datasets by size, but have not provided a valid size_range. Try something like: load_datasets(by='size', size_range=[0,10000])")
+        matching_dataset_ids = filter_by_size(size_range)
+
+    # Confirm at least one match is found
+    if len(matching_dataset_ids) == 0: 
+        raise ValueError(f"No datasets meet the specifications given. The available datasets include {DATASET_LOCATIONS.keys()}")
+   
+    print(f"Found {len(matching_dataset_ids)} datasets that meet the desired specifications: {matching_dataset_ids}. Loading them from data files...")
+   
+    # Load the dataset objects and return 
+    datasets = []
+    for dataset_id in matching_dataset_ids: 
+        dataset=dataset = read_data_from_files(dataset_id=dataset_id, path_to_dataset_downloads = path_to_dataset_downloads)
+        datasets.append(dataset)
+    
+    return datasets
+

--- a/src/scripts/load_datasets.py
+++ b/src/scripts/load_datasets.py
@@ -209,7 +209,8 @@ def load_datasets(by: Literal["id", "category", "size"], ids=[], categories=[], 
     # Load the dataset objects and return 
     datasets = []
     for dataset_id in matching_dataset_ids: 
-        dataset=dataset = read_data_from_files(dataset_id=dataset_id, path_to_dataset_downloads = path_to_dataset_downloads)
+        data = read_data_from_files(dataset_id=dataset_id, path_to_dataset_downloads = path_to_dataset_downloads)
+        dataset = Dataset(dataset_id=dataset_id, data = data)
         datasets.append(dataset)
     
     return datasets


### PR DESCRIPTION
### **1. Download Evaluation Datasets** 

**Goals:**
- Simple to run (no configurations necessary besides huggingface)
- Standardized format
- Accommodate file preferences (csv, json, jsonl)

Result:
     ✅ Download script requires only the dataset names to download
     ✅ Processes in a standardized format (list of Conversation objects)
     ✅ Benchmarks: MMLU, ChatBot Arena, Alpaca Eval 

### 2. Loading Datasets 

**Goals:**
- Easy function for loading datasets
- Load multiple datasets at once 
- Select by name, type (QA, usage data), or size 

Result:
     ✅ load_datasets.py file includes streamlined loading logic. 

### 3. Using Datasets
All datasets to have standardized operations
- Subset: Randomly Sample, Slice by index 
- Get Dataloader 
- Get all samples
- Get Feature (e.g. get all the keys “language”) 
- Get metadata only 
- Get Pandas Dataframe 

Result:
     ✅ datasets_utils.py file includes: standardized dataset class w/ operations 

### 3. Feedback I’m Looking for 
- Is anything confusing? 
- What other functions / capabilities would be helpful to have?
- Right now, we require data to be downloaded first, in order to enforce a standardized structure. Is there any reason this would be prohibitive? 
- Benchmarks to add 
